### PR TITLE
Fix Typo in Running Tests Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python setup.py install
 To run Abseil tests, we use [bazel](https://bazel.build/):
 
 ```bash
-bazel absl/...
+bazel test absl/...
 ```
 
 ### Example Code


### PR DESCRIPTION
I'd never used Bazel before, but I guessed at the command and it worked locally, so I figured I'd save other people that time.

Corrects 'bazel absl/...` to 'bazel test absl/...'