### PR TITLE
Add a Bazel WORKSPACE name.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-workspace(name = "org_abseil_py")
+workspace(name = "io_abseil_py")
 
 new_http_archive(
     name = "six_archive",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+workspace(name = "org_abseil_py")
 
 new_http_archive(
     name = "six_archive",


### PR DESCRIPTION
From Bazel's documentation (https://docs.bazel.build/versions/master/be/functions.html#workspace):
`Each repository's WORKSPACE file should have a workspace(name = "...") line, which sets a global name for the repository.`