### PR TITLE
Use uid instead when username not found.

### DIFF
--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -567,7 +567,11 @@ def find_log_dir_and_names(program_name=None, log_dir=None):
 
   try:
     username = getpass.getuser()
+<<<<<<< HEAD
   except:
+=======
+  except KeyError:
+>>>>>>> Use uid instead when username not found.
     # This can happen, e.g. when running under docker w/o passwd file.
     username = str(os.getuid())
   hostname = socket.gethostname()

--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -565,7 +565,11 @@ def find_log_dir_and_names(program_name=None, log_dir=None):
 
   actual_log_dir = find_log_dir(log_dir=log_dir)
 
-  username = getpass.getuser()
+  try:
+    username = getpass.getuser()
+  except:
+    # This can happen, e.g. when running under docker w/o passwd file.
+    username = str(os.getuid())
   hostname = socket.gethostname()
   file_prefix = '%s.%s.%s.log' % (program_name, hostname, username)
 

--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -567,11 +567,7 @@ def find_log_dir_and_names(program_name=None, log_dir=None):
 
   try:
     username = getpass.getuser()
-<<<<<<< HEAD
-  except:
-=======
   except KeyError:
->>>>>>> Use uid instead when username not found.
     # This can happen, e.g. when running under docker w/o passwd file.
     username = str(os.getuid())
   hostname = socket.gethostname()

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -708,6 +708,25 @@ class LoggingTest(absltest.TestCase):
       self.assertEqual((log_dir, prefix, py_program_name),
                        logging.find_log_dir_and_names())
 
+  def test_find_log_dir_and_names_wo_username(self):
+    uid = 100
+    host = 'test_host'
+    log_dir = 'here'
+    program_name = 'prog1'
+    with mock.patch.object(getpass, 'getuser'), \
+        mock.patch.object(os, 'getuid'), \
+        mock.patch.object(logging, 'find_log_dir') as mock_find_log_dir, \
+        mock.patch.object(socket, 'gethostname') as mock_gethostname:
+      getpass.getuser.side_effect = KeyError()
+      os.getuid.return_value = uid
+      mock_gethostname.return_value = host
+      mock_find_log_dir.return_value = log_dir
+
+      prefix = '%s.%s.%s.log' % (program_name, host, uid)
+      self.assertEqual((log_dir, prefix, program_name),
+                       logging.find_log_dir_and_names(
+                           program_name=program_name, log_dir=log_dir))
+
   def test_errors_in_logging(self):
     with mock.patch.object(sys, 'stderr', new=_StreamIO()) as stderr:
       logging.info('not enough args: %s %s', 'foo')  # pylint: disable=logging-too-few-args


### PR DESCRIPTION
When running under docker, python's getpass.getuser() raises error when there's no passwd file.

```
  File "/nas0/home/sjcho/gorax/deploy/bin/train.runfiles/pypi__absl_py_0_4_0/absl/logging/__init__.py", line 864, in use_absl_log_file
    self._current_handler.use_absl_log_file(program_name, log_dir)
  File "/nas0/home/sjcho/gorax/deploy/bin/train.runfiles/pypi__absl_py_0_4_0/absl/logging/__init__.py", line 731, in use_absl_log_file
    self.start_logging_to_file(program_name=program_name, log_dir=log_dir)
  File "/nas0/home/sjcho/gorax/deploy/bin/train.runfiles/pypi__absl_py_0_4_0/absl/logging/__init__.py", line 699, in start_logging_to_file
    program_name=program_name, log_dir=log_dir)
  File "/nas0/home/sjcho/gorax/deploy/bin/train.runfiles/pypi__absl_py_0_4_0/absl/logging/__init__.py", line 568, in find_log_dir_and_names
    username = getpass.getuser()
  File "/usr/lib/python3.5/getpass.py", line 170, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 5003'
```

This change fixes this by using uid instead of username in such cases.