### PR TITLE
define multi-fields with iterable types

### DIFF
--- a/absl/flags/_flag.py
+++ b/absl/flags/_flag.py
@@ -22,6 +22,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
+import six
 import functools
 
 from absl.flags import _argument_parser
@@ -368,6 +370,9 @@ class MultiFlag(Flag):
     self.present += len(new_values)
 
   def _parse(self, arguments):
+    if isinstance(arguments, collections.Iterable) and not isinstance(arguments, six.string_types):
+      arguments = list(arguments)
+
     if not isinstance(arguments, list):
       # Default value may be a list of values.  Most other arguments
       # will not be, so convert them into a single-item list to make

--- a/absl/flags/tests/flags_test.py
+++ b/absl/flags/tests/flags_test.py
@@ -1184,6 +1184,24 @@ class MultiNumericalFlagsTest(absltest.TestCase):
         expected_floats, FLAGS.get_flag_value('m_float', None)):
       self.assertAlmostEqual(expected, actual)
 
+  def test_mutli_numerical_with_tuples(self):
+      """Test multi_int and multi_float flags when fields are defined as a tuple."""
+
+      int_defaults = (77, 88)
+      flags.DEFINE_multi_integer('m_int_tuple', int_defaults,
+                                 'integer option that can occur multiple times',
+                                 short_name='mi_tuple')
+      self.assertListEqual(FLAGS.get_flag_value('m_int_tuple', None), [77, 88])
+
+      dict_with_float_keys = {2.2: 'hello', 3: 'happy'}
+      float_defaults = dict_with_float_keys.keys()
+      flags.DEFINE_multi_float('m_float_tuple', float_defaults,
+                               'float option that can occur multiple times',
+                               short_name='mf_tuple')
+      for (expected, actual) in zip(
+          float_defaults, FLAGS.get_flag_value('m_float_tuple', None)):
+        self.assertAlmostEqual(expected, actual)
+
   def test_single_value_default(self):
     """Test multi_int and multi_float flags with a single default value."""
     int_default = 77


### PR DESCRIPTION
We can define multi-fields with any kind of iterable instead of just lists. The created flags are always converted to list for consistency.