### PR TITLE
Fixing enum34 requirement for python versions <= 3.4 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,12 @@ setuptools.setup(
     ]),
     install_requires=[
         'six',
-        "enum34; python_version<='3.4'"
     ],
+    extra_requires={
+        ':python_version<="3.4"': [
+          'enum34'
+        ]
+    },
     license='Apache 2.0',
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
Was running into error on Python3.6 and pip 18.1

```
error in absl-py setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected version spec in enum34;python_version<='3.4' at ;python_version<='3.4'
```

Using the `install_requires` and `extra_requires` fixed my problems, and is ostensibly a better way to do this [see reference here](https://github.com/inveniosoftware/troubleshooting/issues/1).