### PR TITLE
Use absolute link to sample app in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ bazel test absl/...
 
 ### Example Code
 
-Please refer to [smoke_tests/sample_app.py](smoke_tests/sample_app.py) as an
-example to get started.
+Please refer to
+[smoke_tests/sample_app.py](https://github.com/abseil/abseil-py/blob/master/smoke_tests/sample_app.py)
+as an example to get started.
 
 ## Documentation
 


### PR DESCRIPTION
This makes the link accessible on the PyPI project page, in addition to on GitHub.