### PR TITLE
Stop PythonHandler closing __stderr__/__stdout__

### DIFF
--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -858,7 +858,8 @@ class PythonHandler(logging.StreamHandler):
         # Do not close the stream if it's sys.stderr|stdout. They may be
         # redirected or overridden to files, which should be managed by users
         # explicitly.
-        if self.stream not in (sys.stderr, sys.stdout) and (
+        user_managed = sys.stderr, sys.stdout, sys.__stderr__, sys.__stdout__
+        if self.stream not in user_managed and (
             not hasattr(self.stream, 'isatty') or not self.stream.isatty()):
           self.stream.close()
       except ValueError:

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -262,6 +262,20 @@ class PythonHandlerTest(absltest.TestCase):
       handler.close()
       mock_stdout.close.assert_not_called()
 
+  def test_close_original_stderr(self):
+    with mock.patch.object(sys, '__stderr__') as mock_original_stderr:
+      mock_original_stderr.isatty.return_value = False
+      handler = logging.PythonHandler(sys.__stderr__)
+      handler.close()
+      mock_original_stderr.close.assert_not_called()
+
+  def test_close_original_stdout(self):
+    with mock.patch.object(sys, '__stdout__') as mock_original_stdout:
+      mock_original_stdout.isatty.return_value = False
+      handler = logging.PythonHandler(sys.__stdout__)
+      handler.close()
+      mock_original_stdout.close.assert_not_called()
+
   def test_close_fake_file(self):
 
     class FakeFile(object):


### PR DESCRIPTION
Closing `__stderr__` or `__stdout__` is problematic in the same ways as
closing `stderr` and `stdout` noted in the code comments.

A specific situation in which this causes a problem:
1. A `PythonHandler` wrapping `stderr` is created and registered.
2. pytest wraps `stderr`, diverging `stderr` and `__stderr__`.
3. `logging.dictConfig` is called, calling `close` on the handler. The
   handler, checking only that the stream is not the current `stderr`,
   closes it.
4. pytest unwraps `stderr`, restoring `sys.__stderr__` to `sys.stderr`
5. pytest-faulthandler attempts to write to the now closed `stderr`
   causing an exception to be raised in pytest internals.