### PR TITLE
Add default known_only to parse_flags_with_usage

### DIFF
--- a/absl/app.py
+++ b/absl/app.py
@@ -143,19 +143,19 @@ class HelpXMLFlag(flags.BooleanFlag):
       sys.exit(1)
 
 
-def parse_flags_with_usage(args):
+def parse_flags_with_usage(args, known_only=False):
   """Tries to parse the flags, print usage, and exit if unparseable.
-
   Args:
     args: [str], a non-empty list of the command line arguments including
         program name.
-
+    known_only: bool, if True, parse and remove known flags; return the rest
+        untouched. Unknown flags specified by --undefok are not returned.     
   Returns:
     [str], a non-empty list of remaining command line arguments after parsing
     flags, including program name.
   """
   try:
-    return FLAGS(args)
+    return FLAGS(args, known_only=known_only)
   except flags.Error as error:
     sys.stderr.write('FATAL Flags parsing error: %s\n' % error)
     sys.stderr.write('Pass --helpshort or --helpfull to see help on flags.\n')


### PR DESCRIPTION
This would allow users to take advantage of the error handling here while still being able to pass custom options on to FLAGS.

An alternative approach would just pass all `kwargs` along; but there's only one and this allows the docstring to stick here as well.