### PR TITLE
Delete PrefixFormatterTest in favor of ABSLLogPrefixTest.

### DIFF
--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -363,28 +363,6 @@ class PythonHandlerTest(absltest.TestCase):
     self.assertTrue(fake_file.closed)
 
 
-class PrefixFormatterTest(absltest.TestCase):
-  """Tests the PrefixFormatter class."""
-
-  def setUp(self):
-    self.now_tuple = time.localtime(time.mktime(
-        (1979, 10, 21, 18, 17, 16, 3, 15, 1)))
-    self.new_prefix = lambda level: '(blah_prefix)'
-    mock.patch.object(time, 'time').start()
-    mock.patch.object(time, 'localtime').start()
-    self.record = std_logging.LogRecord(
-        'name', std_logging.INFO, 'path', 12, 'A Message', [], False)
-    self.formatter = logging.PythonFormatter()
-
-  def tearDown(self):
-    mock.patch.stopall()
-
-  @mock.patch.object(logging._thread_lib, 'get_ident')
-  def test_get_thread_id(self, mock_get_ident):
-    mock_get_ident.return_value = 12345
-    self.assertEqual(12345, logging._get_thread_id())
-
-
 class ABSLHandlerTest(absltest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
Reasoning:

1. The PrefixFormatterTest seems to be a piece of some legacy code that somehow lived to our days.
2. Various mocks set up in the `setUp` method are never used anywhere within the test case.
3. The `setUp` method calls to `time.mktime` which is platform-dependent (for more reading refer to https://docs.python.org/3/library/time.html#time.mktime). It is easy to verify running the PrefixFormatterTest under WSL2, where it crashes with `OverflowError: mktime argument out of range`.
4. The only test does not seem to test anything which is related to any prefix formatter.
5. On the other hand, the same test tests implementation details and not an interface by calling to a private function.
6. Deleting the PrefixFormatterTest  does not affect test coverage in any way.

To sum, it seems that the PrefixFormatterTest doesn't add any value, but increases the maintenance burden.