### PR TITLE
Remove hardcoded tmp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 ## Unreleased
 
-Nothing notable unreleased.
+### Changed
+
+*   If no log dir is specified `logging.find_log_dir()` now falls back to `tempfile.gettempdir()` instead of `/tmp/`.
 
 ## 1.3.0 (2022-10-11)
 

--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -707,7 +707,7 @@ def find_log_dir(log_dir=None):
     FileNotFoundError: raised in Python 3 when it cannot find a log directory.
     OSError: raised in Python 2 when it cannot find a log directory.
   """
-  # Get a list of possible log dirs (will try to use them in order).
+  # Get a possible log dir.
   if log_dir:
     # log_dir was explicitly specified as an arg, so use it and it alone.
     log_dir_candidate = log_dir

--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -87,6 +87,7 @@ import socket
 import struct
 import sys
 import threading
+import tempfile
 import time
 import timeit
 import traceback
@@ -709,18 +710,17 @@ def find_log_dir(log_dir=None):
   # Get a list of possible log dirs (will try to use them in order).
   if log_dir:
     # log_dir was explicitly specified as an arg, so use it and it alone.
-    dirs = [log_dir]
+    log_dir_candidate = log_dir
   elif FLAGS['log_dir'].value:
     # log_dir flag was provided, so use it and it alone (this mimics the
     # behavior of the same flag in logging.cc).
-    dirs = [FLAGS['log_dir'].value]
+    log_dir_candidate = FLAGS['log_dir'].value
   else:
-    dirs = ['/tmp/', './']
+    log_dir_candidate = tempfile.gettempdir()
 
-  # Find the first usable log dir.
-  for d in dirs:
-    if os.path.isdir(d) and os.access(d, os.W_OK):
-      return d
+  # Test if log dir candidate is usable.
+  if os.path.isdir(log_dir_candidate) and os.access(log_dir_candidate, os.W_OK):
+      return log_dir_candidate
   raise FileNotFoundError(
       "Can't find a writable directory for logs, tried %s" % dirs)
 

--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -722,7 +722,7 @@ def find_log_dir(log_dir=None):
   if os.path.isdir(log_dir_candidate) and os.access(log_dir_candidate, os.W_OK):
       return log_dir_candidate
   raise FileNotFoundError(
-      "Can't find a writable directory for logs, tried %s" % dirs)
+      "Can't find a writable directory for logs, tried %s" % log_dir_candidate)
 
 
 def get_absl_log_prefix(record):

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -706,7 +706,7 @@ class LoggingTest(absltest.TestCase):
       os.path.isdir.return_value = True
       os.access.return_value = True
       log_dir = logging.find_log_dir()
-      self.assertEqual('/tmp/', log_dir)
+      self.assertEqual(tempfile.gettempdir(), log_dir)
 
   @flagsaver.flagsaver(log_dir='')
   def test_find_log_dir_with_tmp(self):
@@ -714,10 +714,10 @@ class LoggingTest(absltest.TestCase):
         mock.patch.object(os.path, 'exists'), \
         mock.patch.object(os.path, 'isdir'):
       os.path.exists.return_value = False
-      os.path.isdir.side_effect = lambda path: path == '/tmp/'
+      os.path.isdir.side_effect = lambda path: path == tempfile.gettempdir()
       os.access.return_value = True
       log_dir = logging.find_log_dir()
-      self.assertEqual('/tmp/', log_dir)
+      self.assertEqual(tempfile.gettempdir(), log_dir)
 
   def test_find_log_dir_with_nothing(self):
     with mock.patch.object(os.path, 'exists'), \


### PR DESCRIPTION
the tmp dir might not be at `/tmp/` on every system. `tempfile.gettempdir()` returns the correct folder and falls back to the CWD if there is no usable directory. As `tempfile.gettempdir()` ensures write access to the returned directory, testing `'./'` separately is not necessary.