### PR TITLE
flush should not fail when stderr is None

### DIFF
--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -862,8 +862,9 @@ class PythonHandler(logging.StreamHandler):
     """Flushes all log files."""
     self.acquire()
     try:
-      self.stream.flush()
-    except (EnvironmentError, ValueError, AttributeError):
+      if self.stream and hasattr(self.stream, 'flush'):
+        self.stream.flush()
+    except (EnvironmentError, ValueError):
       # A ValueError is thrown if we try to flush a closed file.
       pass
     finally:

--- a/absl/logging/__init__.py
+++ b/absl/logging/__init__.py
@@ -863,7 +863,7 @@ class PythonHandler(logging.StreamHandler):
     self.acquire()
     try:
       self.stream.flush()
-    except (EnvironmentError, ValueError):
+    except (EnvironmentError, ValueError, AttributeError):
       # A ValueError is thrown if we try to flush a closed file.
       pass
     finally:

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -215,11 +215,15 @@ class PythonHandlerTest(absltest.TestCase):
 
   def test_ignore_flush_if_stream_is_none(self):
     # Happens if creating a Windows executable without console.
-    stream = mock.Mock()
-    stream.flush.side_effect = AttributeError
-    handler = logging.PythonHandler(stream)
+    with mock.patch.object(sys, 'stderr', new=None):
+        handler = logging.PythonHandler(None)
+        # Test that this does not fail.
+        handler.flush()
+
+  def test_ignore_flush_if_stream_does_not_support_flushing(self):
+    handler = logging.PythonHandler('stream')
+    # Test that this does not fail.
     handler.flush()
-    stream.flush.assert_called_once()
 
   def test_log_to_std_err(self):
     record = std_logging.LogRecord(

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -213,6 +213,13 @@ class PythonHandlerTest(absltest.TestCase):
     with self.assertRaises(AssertionError):
       handler.flush()
 
+  def test_ignore_flush_if_stream_is_none(self):
+    # Happens if creating a Windows executable without console.
+    stream = mock.Mock()
+    stream.flush.side_effect = AttributeError
+    handler = logging.PythonHandler(stream)
+    handler.flush()
+
   def test_log_to_std_err(self):
     record = std_logging.LogRecord(
         'name', std_logging.INFO, 'path', 12, 'logging_msg', [], False)

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -219,6 +219,7 @@ class PythonHandlerTest(absltest.TestCase):
     stream.flush.side_effect = AttributeError
     handler = logging.PythonHandler(stream)
     handler.flush()
+    stream.flush.assert_called_once()
 
   def test_log_to_std_err(self):
     record = std_logging.LogRecord(

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -216,9 +216,9 @@ class PythonHandlerTest(absltest.TestCase):
   def test_ignore_flush_if_stream_is_none(self):
     # Happens if creating a Windows executable without console.
     with mock.patch.object(sys, 'stderr', new=None):
-        handler = logging.PythonHandler(None)
-        # Test that this does not fail.
-        handler.flush()
+      handler = logging.PythonHandler(None)
+      # Test that this does not fail.
+      handler.flush()
 
   def test_ignore_flush_if_stream_does_not_support_flushing(self):
     class BadStream:

--- a/absl/logging/tests/logging_test.py
+++ b/absl/logging/tests/logging_test.py
@@ -221,7 +221,10 @@ class PythonHandlerTest(absltest.TestCase):
         handler.flush()
 
   def test_ignore_flush_if_stream_does_not_support_flushing(self):
-    handler = logging.PythonHandler('stream')
+    class BadStream:
+      pass
+
+    handler = logging.PythonHandler(BadStream())
     # Test that this does not fail.
     handler.flush()
 


### PR DESCRIPTION
When running a Windows application created with PyInstaller, logging fails because the stream is set to None.