### PR TITLE
bazel: do not register fallback python toolchains in rdeps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,4 +3,4 @@ module(name = "io_abseil_py")
 bazel_dep(name = "rules_cc", version = "0.2.16")
 bazel_dep(name = "rules_python", version = "1.8.1")
 
-register_toolchains("@rules_python//python/runtime_env_toolchains:all")
+register_toolchains("@rules_python//python/runtime_env_toolchains:all", dev_dependency = True)


### PR DESCRIPTION
`@rules_python//python/runtime_env_toolchains` contains toolchains that [use `python3` installed on the host machine](https://rules-python.readthedocs.io/en/stable/toolchains.html#runtime-environment-toolchain) (not managed by Bazel, not hermetic).

Registering these toolchains results in them being available to all (transitive) Bazel rdeps of `abseil-py`.

Adding `dev_dependency = True` keeps the dev experience for `abseil-py` as is (folks running `bazel` commands in this repo will continue to use their host machine's `python3`) but prevents these toolchains from being registered when `abseil-py` is used as a dependency.